### PR TITLE
Add LLM-as-judge quality scoring with consistency validation

### DIFF
--- a/observatory/cli.py
+++ b/observatory/cli.py
@@ -6,6 +6,7 @@ from rich.table import Table
 
 from observatory.db import get_connection
 from observatory.metrics import BenchmarkMetrics
+from observatory.quality import QualityJudge
 from observatory.runners import RUNNERS
 from observatory.tasks import load_tasks, seed_tasks
 
@@ -189,6 +190,78 @@ def metrics(
             f"{row[10]:.0f}" if row[10] else "—",
         )
     console.print(table)
+
+
+@app.command()
+def score(
+    provider: str = typer.Option(None, "--provider", "-p", help="Filter by provider"),
+    model: str = typer.Option(None, "--model", "-m", help="Filter by model"),
+    task_id: str = typer.Option(None, "--task", "-t", help="Score a single task"),
+    check_consistency: bool = typer.Option(False, "--consistency", "-c", help="Run 3x and report variance"),
+):
+    """Score existing run outputs using LLM-as-judge (claude-sonnet-4-6)."""
+    conn = get_connection()
+
+    where_clauses = ["output_text IS NOT NULL", "output_text != ''"]
+    params = []
+    if provider:
+        where_clauses.append("r.provider = ?")
+        params.append(provider)
+    if model:
+        where_clauses.append("r.model = ?")
+        params.append(model)
+    if task_id:
+        where_clauses.append("r.task_id = ?")
+        params.append(task_id)
+
+    where = f"WHERE {' AND '.join(where_clauses)}"
+
+    rows = conn.execute(
+        f"""
+        SELECT r.id, r.provider, r.model, r.task_id, r.output_text, t.category, t.prompt
+        FROM runs r JOIN tasks t ON r.task_id = t.id
+        {where}
+        ORDER BY r.provider, r.model, r.task_id
+        """,
+        params,
+    ).fetchall()
+
+    if not rows:
+        console.print("[yellow]No runs to score. Run benchmarks first.[/yellow]")
+        return
+
+    judge = QualityJudge()
+    console.print(f"Scoring {len(rows)} runs with [magenta]{judge.model}[/magenta]...\n")
+
+    for run_id, prov, mod, tid, output, category, prompt in rows:
+        console.print(f"  [cyan]{tid}[/cyan] ({prov}/{mod})...", end=" ")
+
+        if check_consistency:
+            result, std_dev = judge.score_with_consistency(category, prompt, output)
+            if result.error:
+                console.print(f"[red]ERROR: {result.error}[/red]")
+                continue
+            consistency = "[green]STABLE[/green]" if std_dev < 0.3 else "[yellow]VARIABLE[/yellow]"
+            console.print(
+                f"[green]{result.overall}/5[/green] std={std_dev} {consistency} "
+                f"({', '.join(f'{k}:{v}' for k, v in result.criteria_scores.items())})"
+            )
+        else:
+            result = judge.score(category, prompt, output)
+            if result.error:
+                console.print(f"[red]ERROR: {result.error}[/red]")
+                continue
+            console.print(
+                f"[green]{result.overall}/5[/green] "
+                f"({', '.join(f'{k}:{v}' for k, v in result.criteria_scores.items())})"
+            )
+
+        conn.execute(
+            "UPDATE runs SET quality_score = ? WHERE id = ?",
+            [result.overall, run_id],
+        )
+
+    console.print("\n[green]Quality scores saved to database.[/green]")
 
 
 if __name__ == "__main__":

--- a/observatory/quality.py
+++ b/observatory/quality.py
@@ -1,0 +1,169 @@
+import json
+import statistics
+from dataclasses import dataclass
+
+from anthropic import Anthropic
+
+JUDGE_MODEL = "claude-sonnet-4-6-20260320"
+
+RUBRICS = {
+    "summarization": {
+        "criteria": [
+            ("accuracy", "Does the summary accurately reflect the source content without fabrication?"),
+            ("completeness", "Does the summary cover all key points from the source?"),
+            ("conciseness", "Is the summary appropriately brief without unnecessary detail?"),
+        ],
+        "max_score": 5,
+    },
+    "extraction": {
+        "criteria": [
+            ("precision", "Are all extracted items actually present in the source?"),
+            ("recall", "Are all relevant items from the source captured?"),
+            ("format", "Is the output in the requested format with correct structure?"),
+        ],
+        "max_score": 5,
+    },
+    "trend_analysis": {
+        "criteria": [
+            ("insight_quality", "Are the identified trends meaningful and non-obvious?"),
+            ("evidence_quality", "Are trends supported with specific references to the source material?"),
+            ("coherence", "Is the analysis logically structured and internally consistent?"),
+        ],
+        "max_score": 5,
+    },
+    "qa": {
+        "criteria": [
+            ("correctness", "Is the answer factually correct based on the source?"),
+            ("grounding", "Is the answer grounded in the source material rather than external knowledge?"),
+            ("completeness", "Does the answer fully address the question asked?"),
+        ],
+        "max_score": 5,
+    },
+}
+
+
+@dataclass
+class QualityScore:
+    overall: float  # 1-5
+    criteria_scores: dict[str, float]  # criterion_name -> score
+    reasoning: str
+    error: str | None = None
+
+
+def _build_judge_prompt(category: str, task_prompt: str, output: str) -> str:
+    rubric = RUBRICS[category]
+    criteria_text = "\n".join(
+        f"- **{name}** (1-5): {desc}" for name, desc in rubric["criteria"]
+    )
+    return f"""You are an expert quality judge for LLM outputs. Score the following output on a 1-5 scale for each criterion.
+
+## Task Category: {category}
+
+## Evaluation Criteria
+{criteria_text}
+
+## Original Task Prompt
+{task_prompt}
+
+## Output to Evaluate
+{output}
+
+## Instructions
+Rate each criterion from 1 (poor) to 5 (excellent). Then provide an overall score (1-5) as the average rounded to one decimal.
+
+Respond with ONLY valid JSON in this exact format:
+{{
+  "criteria_scores": {{"criterion_name": score, ...}},
+  "overall": score,
+  "reasoning": "Brief explanation of scores"
+}}"""
+
+
+class QualityJudge:
+    """Uses a fixed LLM (claude-sonnet-4-6) to score output quality."""
+
+    def __init__(self):
+        self.client = Anthropic()
+        self.model = JUDGE_MODEL
+
+    def score(self, category: str, task_prompt: str, output: str) -> QualityScore:
+        if category not in RUBRICS:
+            return QualityScore(
+                overall=0.0,
+                criteria_scores={},
+                reasoning="",
+                error=f"Unknown category: {category}",
+            )
+
+        prompt = _build_judge_prompt(category, task_prompt, output)
+
+        try:
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=512,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = response.content[0].text.strip()
+            # Handle potential markdown code blocks
+            if text.startswith("```"):
+                text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+            data = json.loads(text)
+            return QualityScore(
+                overall=float(data["overall"]),
+                criteria_scores={k: float(v) for k, v in data["criteria_scores"].items()},
+                reasoning=data.get("reasoning", ""),
+            )
+        except Exception as e:
+            return QualityScore(
+                overall=0.0, criteria_scores={}, reasoning="", error=str(e)
+            )
+
+    def score_with_consistency(
+        self, category: str, task_prompt: str, output: str, runs: int = 3
+    ) -> tuple[QualityScore, float]:
+        """Score multiple times and return the average score + standard deviation."""
+        scores = []
+        all_criteria: dict[str, list[float]] = {}
+        reasonings = []
+
+        for _ in range(runs):
+            result = self.score(category, task_prompt, output)
+            if result.error:
+                continue
+            scores.append(result.overall)
+            reasonings.append(result.reasoning)
+            for k, v in result.criteria_scores.items():
+                all_criteria.setdefault(k, []).append(v)
+
+        if not scores:
+            return QualityScore(
+                overall=0.0, criteria_scores={}, reasoning="", error="All scoring attempts failed"
+            ), 0.0
+
+        avg_overall = statistics.mean(scores)
+        std_dev = statistics.stdev(scores) if len(scores) > 1 else 0.0
+        avg_criteria = {k: statistics.mean(v) for k, v in all_criteria.items()}
+
+        return QualityScore(
+            overall=round(avg_overall, 1),
+            criteria_scores={k: round(v, 1) for k, v in avg_criteria.items()},
+            reasoning=reasonings[0],  # use first reasoning as representative
+        ), round(std_dev, 2)
+
+
+def compute_extraction_precision_recall(
+    extracted: list[str], ground_truth: list[str]
+) -> tuple[float, float, float]:
+    """Compute exact-match precision, recall, and F1 for extraction tasks."""
+    extracted_set = {item.lower().strip() for item in extracted}
+    truth_set = {item.lower().strip() for item in ground_truth}
+
+    if not extracted_set:
+        return 0.0, 0.0, 0.0
+
+    true_positives = len(extracted_set & truth_set)
+    precision = true_positives / len(extracted_set) if extracted_set else 0.0
+    recall = true_positives / len(truth_set) if truth_set else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) > 0 else 0.0
+
+    return round(precision, 3), round(recall, 3), round(f1, 3)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,141 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from observatory.quality import (
+    QualityJudge,
+    QualityScore,
+    RUBRICS,
+    _build_judge_prompt,
+    compute_extraction_precision_recall,
+)
+
+
+def test_rubrics_cover_all_categories():
+    assert set(RUBRICS.keys()) == {"summarization", "extraction", "trend_analysis", "qa"}
+    for cat, rubric in RUBRICS.items():
+        assert len(rubric["criteria"]) == 3
+        assert rubric["max_score"] == 5
+
+
+def test_build_judge_prompt_contains_criteria():
+    prompt = _build_judge_prompt("summarization", "Summarize this", "Some output")
+    assert "accuracy" in prompt
+    assert "completeness" in prompt
+    assert "conciseness" in prompt
+    assert "Summarize this" in prompt
+    assert "Some output" in prompt
+
+
+def test_quality_score_dataclass():
+    qs = QualityScore(
+        overall=4.2,
+        criteria_scores={"accuracy": 4.0, "completeness": 4.5},
+        reasoning="Good output",
+    )
+    assert qs.overall == 4.2
+    assert qs.error is None
+
+
+def test_quality_judge_unknown_category():
+    judge = QualityJudge.__new__(QualityJudge)  # skip __init__ to avoid API client
+    result = judge.score("nonexistent", "prompt", "output")
+    assert result.error is not None
+    assert "Unknown category" in result.error
+
+
+def test_quality_judge_score():
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=json.dumps({
+        "criteria_scores": {"accuracy": 4.0, "completeness": 5.0, "conciseness": 3.0},
+        "overall": 4.0,
+        "reasoning": "Good summary",
+    }))]
+
+    with patch("observatory.quality.Anthropic") as MockClient:
+        mock_client = MagicMock()
+        MockClient.return_value = mock_client
+        mock_client.messages.create.return_value = mock_response
+
+        judge = QualityJudge()
+        result = judge.score("summarization", "Summarize this", "Key points: ...")
+        assert result.overall == 4.0
+        assert result.criteria_scores["accuracy"] == 4.0
+        assert result.error is None
+
+
+def test_quality_judge_handles_markdown_code_blocks():
+    json_str = json.dumps({
+        "criteria_scores": {"correctness": 5.0, "grounding": 4.0, "completeness": 4.0},
+        "overall": 4.3,
+        "reasoning": "Accurate",
+    })
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=f"```json\n{json_str}\n```")]
+
+    with patch("observatory.quality.Anthropic") as MockClient:
+        mock_client = MagicMock()
+        MockClient.return_value = mock_client
+        mock_client.messages.create.return_value = mock_response
+
+        judge = QualityJudge()
+        result = judge.score("qa", "What is X?", "X is Y")
+        assert result.overall == 4.3
+        assert result.error is None
+
+
+def test_quality_judge_score_with_consistency():
+    scores = [
+        {"criteria_scores": {"accuracy": 4.0}, "overall": 4.0, "reasoning": "r1"},
+        {"criteria_scores": {"accuracy": 4.0}, "overall": 4.2, "reasoning": "r2"},
+        {"criteria_scores": {"accuracy": 4.0}, "overall": 4.1, "reasoning": "r3"},
+    ]
+    call_count = {"n": 0}
+
+    def mock_create(**kwargs):
+        resp = MagicMock()
+        resp.content = [MagicMock(text=json.dumps(scores[call_count["n"]]))]
+        call_count["n"] += 1
+        return resp
+
+    with patch("observatory.quality.Anthropic") as MockClient:
+        mock_client = MagicMock()
+        MockClient.return_value = mock_client
+        mock_client.messages.create.side_effect = mock_create
+
+        judge = QualityJudge()
+        result, std_dev = judge.score_with_consistency("summarization", "Prompt", "Output")
+        assert result.overall == 4.1  # mean of 4.0, 4.2, 4.1
+        assert std_dev < 0.3  # should be stable
+
+
+def test_extraction_precision_recall_perfect():
+    p, r, f1 = compute_extraction_precision_recall(
+        ["Apple", "Google"], ["Apple", "Google"]
+    )
+    assert p == 1.0
+    assert r == 1.0
+    assert f1 == 1.0
+
+
+def test_extraction_precision_recall_partial():
+    p, r, f1 = compute_extraction_precision_recall(
+        ["Apple", "Microsoft"], ["Apple", "Google"]
+    )
+    assert p == 0.5  # 1/2 extracted are correct
+    assert r == 0.5  # 1/2 ground truth found
+    assert f1 == 0.5
+
+
+def test_extraction_precision_recall_empty():
+    p, r, f1 = compute_extraction_precision_recall([], ["Apple"])
+    assert p == 0.0
+    assert r == 0.0
+    assert f1 == 0.0
+
+
+def test_extraction_precision_recall_case_insensitive():
+    p, r, f1 = compute_extraction_precision_recall(
+        ["apple", "GOOGLE"], ["Apple", "Google"]
+    )
+    assert p == 1.0
+    assert r == 1.0


### PR DESCRIPTION
## Summary
- `QualityJudge` using fixed `claude-sonnet-4-6` to score outputs on category-specific rubrics (1-5 scale, 3 criteria each)
- `score_with_consistency` runs judge 3x and reports std dev (< 0.3 = stable)
- `compute_extraction_precision_recall` for exact-match evaluation against ground truth
- CLI `score` command with `--consistency` flag, scores existing runs and saves quality_score to DB

## Test plan
- [x] All 31 tests pass (11 new quality tests + 20 existing)
- [x] Rubrics cover all 4 categories with 3 criteria each
- [x] Judge handles markdown code block wrapping
- [x] Consistency check validates std dev < 0.3
- [x] Precision/recall handles perfect, partial, empty, and case-insensitive matching

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)