### PR TITLE
Add BenchmarkDB query layer with indexes and CLI commands

### DIFF
--- a/observatory/cli.py
+++ b/observatory/cli.py
@@ -4,7 +4,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from observatory.db import get_connection
+from observatory.db import BenchmarkDB, get_connection
 from observatory.metrics import BenchmarkMetrics
 from observatory.quality import QualityJudge
 from observatory.runners import RUNNERS
@@ -262,6 +262,134 @@ def score(
         )
 
     console.print("\n[green]Quality scores saved to database.[/green]")
+
+
+@app.command()
+def summary(
+    provider: str = typer.Argument(help="Provider to summarize"),
+    days: int = typer.Option(30, "--days", "-d", help="Look back N days"),
+):
+    """Show provider summary: avg latency, cost, quality per model."""
+    db = BenchmarkDB()
+    rows = db.get_provider_summary(provider, days)
+    if not rows:
+        console.print(f"[yellow]No data for provider '{provider}' in the last {days} days.[/yellow]")
+        return
+
+    table = Table(title=f"Provider Summary: {provider} (last {days} days)")
+    table.add_column("Model", style="cyan")
+    table.add_column("Runs", justify="right")
+    table.add_column("Avg (ms)", justify="right")
+    table.add_column("p50 (ms)", justify="right", style="green")
+    table.add_column("p95 (ms)", justify="right", style="yellow")
+    table.add_column("Cost ($)", justify="right")
+    table.add_column("Avg Cost", justify="right")
+    table.add_column("Quality", justify="right", style="blue")
+    table.add_column("tok/s", justify="right")
+
+    for r in rows:
+        table.add_row(
+            r["model"], str(r["total_runs"]),
+            f"{r['avg_latency_ms']:.0f}", f"{r['p50_latency_ms']:.0f}", f"{r['p95_latency_ms']:.0f}",
+            f"{r['total_cost']:.6f}", f"{r['avg_cost']:.6f}",
+            f"{r['avg_quality']:.1f}" if r["avg_quality"] else "—",
+            f"{r['avg_tok_per_sec']:.1f}" if r["avg_tok_per_sec"] else "—",
+        )
+    console.print(table)
+
+
+@app.command()
+def breakdown(
+    task_id: str = typer.Argument(help="Task ID to break down"),
+):
+    """Compare all providers/models on a single task."""
+    db = BenchmarkDB()
+    rows = db.get_task_breakdown(task_id)
+    if not rows:
+        console.print(f"[yellow]No data for task '{task_id}'.[/yellow]")
+        return
+
+    table = Table(title=f"Task Breakdown: {task_id}")
+    table.add_column("Provider", style="magenta")
+    table.add_column("Model", style="cyan")
+    table.add_column("Runs", justify="right")
+    table.add_column("Avg (ms)", justify="right")
+    table.add_column("p50 (ms)", justify="right", style="green")
+    table.add_column("Avg Cost", justify="right")
+    table.add_column("Quality", justify="right", style="blue")
+    table.add_column("tok/s", justify="right")
+
+    for r in rows:
+        table.add_row(
+            r["provider"], r["model"], str(r["runs"]),
+            f"{r['avg_latency_ms']:.0f}", f"{r['p50_latency_ms']:.0f}",
+            f"{r['avg_cost']:.6f}",
+            f"{r['avg_quality']:.1f}" if r["avg_quality"] else "—",
+            f"{r['avg_tok_per_sec']:.1f}" if r["avg_tok_per_sec"] else "—",
+        )
+    console.print(table)
+
+
+@app.command()
+def trend(
+    provider: str = typer.Argument(help="Provider name"),
+    model: str = typer.Argument(help="Model name"),
+    metric: str = typer.Argument(help="Metric: latency_ms, cost_usd, quality_score, tokens_out"),
+    days: int = typer.Option(30, "--days", "-d", help="Look back N days"),
+):
+    """Show daily trend of a metric over time."""
+    db = BenchmarkDB()
+    try:
+        rows = db.get_trend(provider, model, metric, days)
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1)
+
+    if not rows:
+        console.print(f"[yellow]No trend data for {provider}/{model}.[/yellow]")
+        return
+
+    table = Table(title=f"Trend: {provider}/{model} — {metric} (last {days} days)")
+    table.add_column("Day", style="cyan")
+    table.add_column("Avg", justify="right", style="green")
+    table.add_column("Min", justify="right")
+    table.add_column("Max", justify="right")
+    table.add_column("Runs", justify="right")
+
+    for r in rows:
+        day_str = str(r["day"])[:10]
+        table.add_row(
+            day_str,
+            f"{r['avg_value']:.2f}",
+            f"{r['min_value']:.2f}",
+            f"{r['max_value']:.2f}",
+            str(r["runs"]),
+        )
+    console.print(table)
+
+
+@app.command()
+def pareto():
+    """Show cost vs. quality Pareto frontier."""
+    db = BenchmarkDB()
+    rows = db.get_pareto_front()
+    if not rows:
+        console.print("[yellow]No scored runs found. Run benchmarks and score them first.[/yellow]")
+        return
+
+    table = Table(title="Pareto Frontier: Cost vs. Quality")
+    table.add_column("Provider", style="magenta")
+    table.add_column("Model", style="cyan")
+    table.add_column("Avg Cost ($)", justify="right")
+    table.add_column("Avg Quality", justify="right", style="green")
+
+    for r in rows:
+        table.add_row(
+            r["provider"], r["model"],
+            f"{r['avg_cost']:.6f}",
+            f"{r['avg_quality']:.1f}",
+        )
+    console.print(table)
 
 
 if __name__ == "__main__":

--- a/observatory/db.py
+++ b/observatory/db.py
@@ -1,5 +1,8 @@
-import duckdb
+import uuid
+from dataclasses import asdict
 from pathlib import Path
+
+import duckdb
 
 DB_PATH = Path("observatory.duckdb")
 
@@ -32,8 +35,164 @@ CREATE TABLE IF NOT EXISTS runs (
 );
 """
 
+INDEXES = """
+CREATE INDEX IF NOT EXISTS idx_runs_timestamp ON runs(timestamp);
+CREATE INDEX IF NOT EXISTS idx_runs_provider ON runs(provider);
+CREATE INDEX IF NOT EXISTS idx_runs_task_id ON runs(task_id);
+"""
+
 
 def get_connection(db_path: Path = DB_PATH) -> duckdb.DuckDBPyConnection:
     conn = duckdb.connect(str(db_path))
     conn.execute(SCHEMA)
+    conn.execute(INDEXES)
     return conn
+
+
+class BenchmarkDB:
+    """High-level query interface for benchmark results."""
+
+    def __init__(self, db_path: Path = DB_PATH):
+        self.conn = get_connection(db_path)
+
+    def insert_run(
+        self,
+        provider: str,
+        model: str,
+        task_id: str,
+        latency_ms: float,
+        tokens_in: int,
+        tokens_out: int,
+        cost_usd: float,
+        output_text: str = "",
+        quality_score: float | None = None,
+        avg_cpu_percent: float = 0.0,
+        avg_memory_percent: float = 0.0,
+        run_index: int = 0,
+        batch_id: str | None = None,
+    ) -> str:
+        """Insert a single run result. Returns the generated run ID."""
+        run_id = str(uuid.uuid4())
+        self.conn.execute(
+            """
+            INSERT INTO runs (id, provider, model, task_id, latency_ms, tokens_in, tokens_out,
+                              cost_usd, output_text, quality_score, avg_cpu_percent,
+                              avg_memory_percent, run_index, batch_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [run_id, provider, model, task_id, latency_ms, tokens_in, tokens_out,
+             cost_usd, output_text, quality_score, avg_cpu_percent, avg_memory_percent,
+             run_index, batch_id],
+        )
+        return run_id
+
+    def get_provider_summary(self, provider: str, days: int = 30) -> list[dict]:
+        """Average latency, cost, and quality per model for a provider over N days."""
+        rows = self.conn.execute(
+            f"""
+            SELECT
+                model,
+                COUNT(*) as total_runs,
+                AVG(latency_ms) as avg_latency_ms,
+                PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY latency_ms) as p50_latency_ms,
+                PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY latency_ms) as p95_latency_ms,
+                SUM(cost_usd) as total_cost,
+                AVG(cost_usd) as avg_cost,
+                AVG(quality_score) as avg_quality,
+                AVG(tokens_out) * 1000.0 / NULLIF(AVG(latency_ms), 0) as avg_tok_per_sec
+            FROM runs
+            WHERE provider = ?
+              AND timestamp >= current_timestamp - INTERVAL '{days}' DAY
+            GROUP BY model
+            ORDER BY model
+            """,
+            [provider],
+        ).fetchall()
+        columns = ["model", "total_runs", "avg_latency_ms", "p50_latency_ms",
+                    "p95_latency_ms", "total_cost", "avg_cost", "avg_quality", "avg_tok_per_sec"]
+        return [dict(zip(columns, row)) for row in rows]
+
+    def get_task_breakdown(self, task_id: str) -> list[dict]:
+        """All providers/models side by side for a single task."""
+        rows = self.conn.execute(
+            """
+            SELECT
+                provider,
+                model,
+                COUNT(*) as runs,
+                AVG(latency_ms) as avg_latency_ms,
+                PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY latency_ms) as p50_latency_ms,
+                AVG(cost_usd) as avg_cost,
+                AVG(quality_score) as avg_quality,
+                AVG(tokens_out) * 1000.0 / NULLIF(AVG(latency_ms), 0) as avg_tok_per_sec
+            FROM runs
+            WHERE task_id = ?
+            GROUP BY provider, model
+            ORDER BY avg_quality DESC NULLS LAST, avg_latency_ms ASC
+            """,
+            [task_id],
+        ).fetchall()
+        columns = ["provider", "model", "runs", "avg_latency_ms", "p50_latency_ms",
+                    "avg_cost", "avg_quality", "avg_tok_per_sec"]
+        return [dict(zip(columns, row)) for row in rows]
+
+    def get_trend(self, provider: str, model: str, metric: str, days: int = 30) -> list[dict]:
+        """Daily trend of a metric over time.
+
+        Valid metrics: latency_ms, cost_usd, quality_score, tokens_out.
+        """
+        valid_metrics = {"latency_ms", "cost_usd", "quality_score", "tokens_out"}
+        if metric not in valid_metrics:
+            raise ValueError(f"Invalid metric: {metric}. Choose from: {valid_metrics}")
+
+        rows = self.conn.execute(
+            f"""
+            SELECT
+                DATE_TRUNC('day', timestamp) as day,
+                AVG({metric}) as avg_value,
+                MIN({metric}) as min_value,
+                MAX({metric}) as max_value,
+                COUNT(*) as runs
+            FROM runs
+            WHERE provider = ?
+              AND model = ?
+              AND timestamp >= current_timestamp - INTERVAL '{days}' DAY
+            GROUP BY day
+            ORDER BY day
+            """,
+            [provider, model],
+        ).fetchall()
+        columns = ["day", "avg_value", "min_value", "max_value", "runs"]
+        return [dict(zip(columns, row)) for row in rows]
+
+    def get_pareto_front(self) -> list[dict]:
+        """Cost vs. quality Pareto frontier — models not dominated on both axes."""
+        rows = self.conn.execute(
+            """
+            WITH model_stats AS (
+                SELECT
+                    provider,
+                    model,
+                    AVG(cost_usd) as avg_cost,
+                    AVG(quality_score) as avg_quality
+                FROM runs
+                WHERE quality_score IS NOT NULL
+                GROUP BY provider, model
+            )
+            SELECT
+                a.provider,
+                a.model,
+                a.avg_cost,
+                a.avg_quality
+            FROM model_stats a
+            WHERE NOT EXISTS (
+                SELECT 1 FROM model_stats b
+                WHERE b.avg_cost <= a.avg_cost
+                  AND b.avg_quality >= a.avg_quality
+                  AND (b.avg_cost < a.avg_cost OR b.avg_quality > a.avg_quality)
+            )
+            ORDER BY a.avg_cost ASC
+            """,
+        ).fetchall()
+        columns = ["provider", "model", "avg_cost", "avg_quality"]
+        return [dict(zip(columns, row)) for row in rows]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,119 @@
+import tempfile
+from pathlib import Path
+
+from observatory.db import BenchmarkDB, get_connection
+from observatory.tasks import seed_tasks
+
+
+def _setup_db() -> BenchmarkDB:
+    """Create a temp DB with tasks seeded and some sample runs."""
+    d = tempfile.mkdtemp()
+    db_path = Path(d) / "test.duckdb"
+    db = BenchmarkDB(db_path)
+    seed_tasks(conn=db.conn)
+
+    # Insert sample runs for two providers
+    for i in range(5):
+        db.insert_run(
+            provider="openai", model="gpt-4o-mini", task_id="sum-01",
+            latency_ms=100 + i * 20, tokens_in=50, tokens_out=100,
+            cost_usd=0.001, quality_score=4.0 + i * 0.1,
+        )
+        db.insert_run(
+            provider="anthropic", model="claude-haiku-4-5-20251001", task_id="sum-01",
+            latency_ms=80 + i * 10, tokens_in=50, tokens_out=120,
+            cost_usd=0.002, quality_score=4.5,
+        )
+    # A second task for openai
+    for i in range(3):
+        db.insert_run(
+            provider="openai", model="gpt-4o-mini", task_id="ext-01",
+            latency_ms=200 + i * 30, tokens_in=60, tokens_out=80,
+            cost_usd=0.0015, quality_score=3.5,
+        )
+    return db
+
+
+def test_insert_run_returns_id():
+    d = tempfile.mkdtemp()
+    db = BenchmarkDB(Path(d) / "test.duckdb")
+    seed_tasks(conn=db.conn)
+    run_id = db.insert_run(
+        provider="openai", model="gpt-4o-mini", task_id="sum-01",
+        latency_ms=150, tokens_in=50, tokens_out=100, cost_usd=0.001,
+    )
+    assert isinstance(run_id, str)
+    assert len(run_id) == 36  # UUID format
+
+
+def test_get_provider_summary():
+    db = _setup_db()
+    rows = db.get_provider_summary("openai")
+    assert len(rows) == 1  # one model
+    row = rows[0]
+    assert row["model"] == "gpt-4o-mini"
+    assert row["total_runs"] == 8  # 5 sum-01 + 3 ext-01
+    assert row["avg_latency_ms"] > 0
+    assert row["total_cost"] > 0
+
+
+def test_get_provider_summary_empty():
+    db = _setup_db()
+    rows = db.get_provider_summary("nonexistent")
+    assert rows == []
+
+
+def test_get_task_breakdown():
+    db = _setup_db()
+    rows = db.get_task_breakdown("sum-01")
+    assert len(rows) == 2  # openai + anthropic
+    providers = {r["provider"] for r in rows}
+    assert providers == {"openai", "anthropic"}
+
+
+def test_get_task_breakdown_empty():
+    db = _setup_db()
+    rows = db.get_task_breakdown("nonexistent-task")
+    assert rows == []
+
+
+def test_get_trend():
+    db = _setup_db()
+    rows = db.get_trend("openai", "gpt-4o-mini", "latency_ms", days=30)
+    assert len(rows) >= 1
+    row = rows[0]
+    assert "avg_value" in row
+    assert "min_value" in row
+    assert "max_value" in row
+    assert row["runs"] > 0
+
+
+def test_get_trend_invalid_metric():
+    db = _setup_db()
+    try:
+        db.get_trend("openai", "gpt-4o-mini", "invalid_metric")
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "Invalid metric" in str(e)
+
+
+def test_get_pareto_front():
+    db = _setup_db()
+    rows = db.get_pareto_front()
+    assert len(rows) >= 1
+    # All Pareto-optimal models should have quality scores
+    for r in rows:
+        assert r["avg_quality"] is not None
+        assert r["avg_cost"] is not None
+
+
+def test_indexes_created():
+    d = tempfile.mkdtemp()
+    db = BenchmarkDB(Path(d) / "test.duckdb")
+    indexes = db.conn.execute(
+        "SELECT index_name FROM duckdb_indexes()"
+    ).fetchall()
+    index_names = {i[0] for i in indexes}
+    assert "idx_runs_timestamp" in index_names
+    assert "idx_runs_provider" in index_names
+    assert "idx_runs_task_id" in index_names


### PR DESCRIPTION
## Summary
- `BenchmarkDB` class with `insert_run`, `get_provider_summary`, `get_task_breakdown`, `get_trend`, `get_pareto_front`
- DuckDB indexes on timestamp, provider, and task_id for efficient querying
- CLI commands: `summary`, `breakdown`, `trend`, `pareto`
- Pareto frontier computed via SQL anti-join (models not dominated on both cost and quality)

## Test plan
- [x] All 40 tests pass (9 new DB tests + 31 existing)
- [x] insert_run returns valid UUID
- [x] Provider summary aggregates correctly across models
- [x] Task breakdown shows all providers side by side
- [x] Trend returns daily aggregated data
- [x] Invalid metric raises ValueError
- [x] Pareto front returns non-dominated models
- [x] All 3 indexes verified created

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)