### PR TITLE
Add daily automated benchmark with cost estimation and launchd schedule

### DIFF
--- a/observatory/benchmark.py
+++ b/observatory/benchmark.py
@@ -1,0 +1,160 @@
+"""Automated benchmark runner across all configured providers."""
+
+import subprocess
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+from observatory.db import BenchmarkDB, get_connection
+from observatory.runners import RUNNERS
+from observatory.runners.openai_runner import PRICING as OPENAI_PRICING
+from observatory.runners.anthropic_runner import PRICING as ANTHROPIC_PRICING, MODEL_ALIASES
+from observatory.tasks import load_tasks, seed_tasks
+
+# Default models per provider
+DEFAULT_MODELS = {
+    "ollama": ["llama3.2", "gemma3", "mistral"],
+    "mlx": ["mlx-community/Llama-3.2-3B-Instruct-4bit"],
+    "openai": ["gpt-4o-mini", "gpt-4o"],
+    "anthropic": ["claude-haiku-4-5", "claude-sonnet-4-6"],
+}
+
+# Average tokens per task (estimated for cost projection)
+AVG_TOKENS_PER_TASK = {"input": 500, "output": 300}
+
+
+def estimate_cost(
+    providers: list[str],
+    num_tasks: int = 20,
+    repeats: int = 5,
+) -> dict[str, float]:
+    """Estimate cost per provider for a full benchmark run.
+
+    Returns dict of provider -> estimated cost in USD.
+    """
+    estimates = {}
+    for provider in providers:
+        if provider in ("ollama", "mlx"):
+            estimates[provider] = 0.0
+            continue
+
+        models = DEFAULT_MODELS.get(provider, [])
+        total = 0.0
+        for model in models:
+            if provider == "openai":
+                prices = OPENAI_PRICING.get(model, {"input": 0, "output": 0})
+            elif provider == "anthropic":
+                resolved = MODEL_ALIASES.get(model, model)
+                prices = ANTHROPIC_PRICING.get(resolved, {"input": 0, "output": 0})
+            else:
+                prices = {"input": 0, "output": 0}
+
+            per_run = (
+                AVG_TOKENS_PER_TASK["input"] * prices["input"]
+                + AVG_TOKENS_PER_TASK["output"] * prices["output"]
+            ) / 1_000_000
+            total += per_run * num_tasks * repeats
+
+        estimates[provider] = round(total, 4)
+
+    return estimates
+
+
+def run_benchmark(
+    providers: list[str] | None = None,
+    repeats: int = 5,
+    log_path: Path | None = None,
+) -> dict:
+    """Run all benchmark tasks across specified providers.
+
+    Returns a summary dict with results per provider/model.
+    """
+    if providers is None:
+        providers = list(DEFAULT_MODELS.keys())
+
+    tasks = load_tasks()
+    db = BenchmarkDB()
+    seed_tasks(conn=db.conn)
+    batch_id = str(uuid.uuid4())
+
+    results = {}
+    total_runs = 0
+    total_errors = 0
+
+    for provider in providers:
+        if provider not in RUNNERS:
+            continue
+
+        models = DEFAULT_MODELS.get(provider, [])
+        runner_cls = RUNNERS[provider]
+
+        for model in models:
+            key = f"{provider}/{model}"
+            runner = runner_cls(model=model)
+            model_results = {"runs": 0, "errors": 0, "latencies": [], "costs": []}
+
+            for task in tasks:
+                for i in range(repeats):
+                    result = runner.run(task, collect_system_metrics=runner.is_local)
+
+                    if result.error:
+                        model_results["errors"] += 1
+                        total_errors += 1
+                        continue
+
+                    avg_cpu = 0.0
+                    avg_mem = 0.0
+                    if result.system_snapshots:
+                        avg_cpu = sum(s.cpu_percent for s in result.system_snapshots) / len(result.system_snapshots)
+                        avg_mem = sum(s.memory_percent for s in result.system_snapshots) / len(result.system_snapshots)
+
+                    db.insert_run(
+                        provider=provider,
+                        model=model if provider != "anthropic" else MODEL_ALIASES.get(model, model),
+                        task_id=task["id"],
+                        latency_ms=result.latency_ms,
+                        tokens_in=result.tokens_in,
+                        tokens_out=result.tokens_out,
+                        cost_usd=result.cost_usd,
+                        output_text=result.output,
+                        avg_cpu_percent=avg_cpu,
+                        avg_memory_percent=avg_mem,
+                        run_index=i,
+                        batch_id=batch_id,
+                    )
+
+                    model_results["runs"] += 1
+                    model_results["latencies"].append(result.latency_ms)
+                    model_results["costs"].append(result.cost_usd)
+                    total_runs += 1
+
+            results[key] = model_results
+
+    summary = {
+        "batch_id": batch_id,
+        "timestamp": datetime.now().isoformat(),
+        "total_runs": total_runs,
+        "total_errors": total_errors,
+        "total_cost": sum(
+            sum(r["costs"]) for r in results.values()
+        ),
+        "providers": results,
+    }
+
+    return summary
+
+
+def send_macos_notification(title: str, message: str):
+    """Send a macOS notification via osascript."""
+    script = f'display notification "{message}" with title "{title}"'
+    subprocess.run(["osascript", "-e", script], capture_output=True)
+
+
+def format_summary_notification(summary: dict) -> str:
+    """Format a 3-line summary for notification."""
+    lines = [
+        f"Runs: {summary['total_runs']} | Errors: {summary['total_errors']}",
+        f"Cost: ${summary['total_cost']:.4f}",
+        f"Providers: {len(summary['providers'])} models benchmarked",
+    ]
+    return "\n".join(lines)

--- a/observatory/cli.py
+++ b/observatory/cli.py
@@ -4,6 +4,13 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from observatory.benchmark import (
+    DEFAULT_MODELS,
+    estimate_cost,
+    format_summary_notification,
+    run_benchmark,
+    send_macos_notification,
+)
 from observatory.db import BenchmarkDB, get_connection
 from observatory.metrics import BenchmarkMetrics
 from observatory.quality import QualityJudge
@@ -390,6 +397,129 @@ def pareto():
             f"{r['avg_quality']:.1f}",
         )
     console.print(table)
+
+
+@app.command()
+def benchmark(
+    providers: list[str] = typer.Option(None, "--provider", "-p", help="Providers to benchmark (repeatable)"),
+    repeats: int = typer.Option(5, "--repeats", "-n", help="Runs per task per model"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip cost confirmation"),
+    notify: bool = typer.Option(True, "--notify/--no-notify", help="Send macOS notification on completion"),
+):
+    """Run full benchmark across all providers and models."""
+    if not providers:
+        providers = list(DEFAULT_MODELS.keys())
+
+    # Estimate cost and confirm
+    costs = estimate_cost(providers, num_tasks=20, repeats=repeats)
+    total_cost = sum(costs.values())
+
+    console.print("[bold]Estimated cost:[/bold]")
+    for p, c in costs.items():
+        console.print(f"  {p}: ${c:.4f}")
+    console.print(f"  [bold]Total: ${total_cost:.4f}[/bold]\n")
+
+    if total_cost > 2.0 and not yes:
+        confirm = typer.confirm(f"Estimated cost ${total_cost:.4f} exceeds $2. Continue?")
+        if not confirm:
+            console.print("[yellow]Aborted.[/yellow]")
+            raise typer.Exit(0)
+
+    console.print(f"Starting benchmark: {len(providers)} providers, {repeats} repeats per task...\n")
+    result = run_benchmark(providers=providers, repeats=repeats)
+
+    console.print(f"\n[green]Benchmark complete![/green]")
+    console.print(f"  Batch: {result['batch_id']}")
+    console.print(f"  Total runs: {result['total_runs']}")
+    console.print(f"  Total errors: {result['total_errors']}")
+    console.print(f"  Total cost: ${result['total_cost']:.4f}")
+
+    if notify:
+        msg = format_summary_notification(result)
+        send_macos_notification("Inference Observatory", msg)
+
+
+@app.command()
+def install_schedule():
+    """Install launchd plist for daily automated benchmarks at 6am."""
+    import os
+    plist_dir = Path.home() / "Library" / "LaunchAgents"
+    plist_dir.mkdir(parents=True, exist_ok=True)
+    plist_path = plist_dir / "com.inference-observatory.plist"
+
+    log_dir = Path.home() / ".inference-observatory" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    working_dir = Path.cwd()
+    python_path = subprocess.run(
+        ["which", "python3"], capture_output=True, text=True
+    ).stdout.strip()
+
+    plist_content = f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.inference-observatory</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{python_path}</string>
+        <string>-m</string>
+        <string>observatory.cli</string>
+        <string>benchmark</string>
+        <string>--yes</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>{working_dir}</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>6</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{log_dir}/benchmark.log</string>
+    <key>StandardErrorPath</key>
+    <string>{log_dir}/benchmark-error.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>{os.environ.get('PATH', '/usr/local/bin:/usr/bin:/bin')}</string>
+        <key>OPENAI_API_KEY</key>
+        <string>{os.environ.get('OPENAI_API_KEY', '')}</string>
+        <key>ANTHROPIC_API_KEY</key>
+        <string>{os.environ.get('ANTHROPIC_API_KEY', '')}</string>
+    </dict>
+</dict>
+</plist>"""
+
+    plist_path.write_text(plist_content)
+    console.print(f"[green]Plist written to {plist_path}[/green]")
+
+    # Load the agent
+    subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
+    result = subprocess.run(["launchctl", "load", str(plist_path)], capture_output=True, text=True)
+    if result.returncode == 0:
+        console.print("[green]Schedule installed! Daily benchmark at 6:00 AM.[/green]")
+    else:
+        console.print(f"[yellow]launchctl load returned: {result.stderr}[/yellow]")
+        console.print(f"You can manually load with: launchctl load {plist_path}")
+
+    console.print(f"Logs: {log_dir}/")
+
+
+@app.command()
+def uninstall_schedule():
+    """Uninstall the launchd daily benchmark schedule."""
+    plist_path = Path.home() / "Library" / "LaunchAgents" / "com.inference-observatory.plist"
+    if not plist_path.exists():
+        console.print("[yellow]No schedule found.[/yellow]")
+        return
+
+    subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
+    plist_path.unlink()
+    console.print("[green]Schedule uninstalled.[/green]")
 
 
 if __name__ == "__main__":

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,68 @@
+from unittest.mock import patch, MagicMock
+
+from observatory.benchmark import (
+    DEFAULT_MODELS,
+    estimate_cost,
+    format_summary_notification,
+    run_benchmark,
+)
+
+
+def test_default_models_all_providers():
+    assert "ollama" in DEFAULT_MODELS
+    assert "mlx" in DEFAULT_MODELS
+    assert "openai" in DEFAULT_MODELS
+    assert "anthropic" in DEFAULT_MODELS
+
+
+def test_estimate_cost_local_free():
+    costs = estimate_cost(["ollama", "mlx"])
+    assert costs["ollama"] == 0.0
+    assert costs["mlx"] == 0.0
+
+
+def test_estimate_cost_api_positive():
+    costs = estimate_cost(["openai"])
+    assert costs["openai"] > 0
+
+
+def test_estimate_cost_anthropic_positive():
+    costs = estimate_cost(["anthropic"])
+    assert costs["anthropic"] > 0
+
+
+def test_estimate_cost_scales_with_repeats():
+    costs_1 = estimate_cost(["openai"], repeats=1)
+    costs_5 = estimate_cost(["openai"], repeats=5)
+    assert costs_5["openai"] == costs_1["openai"] * 5
+
+
+def test_estimate_cost_scales_with_tasks():
+    costs_10 = estimate_cost(["openai"], num_tasks=10)
+    costs_20 = estimate_cost(["openai"], num_tasks=20)
+    assert abs(costs_20["openai"] - costs_10["openai"] * 2) < 0.001
+
+
+def test_format_summary_notification():
+    summary = {
+        "total_runs": 100,
+        "total_errors": 2,
+        "total_cost": 0.1234,
+        "providers": {"a/m1": {}, "b/m2": {}},
+    }
+    msg = format_summary_notification(summary)
+    assert "100" in msg
+    assert "2" in msg
+    assert "$0.1234" in msg
+    assert "2 models" in msg
+
+
+def test_format_summary_notification_zero():
+    summary = {
+        "total_runs": 0,
+        "total_errors": 0,
+        "total_cost": 0.0,
+        "providers": {},
+    }
+    msg = format_summary_notification(summary)
+    assert "0" in msg


### PR DESCRIPTION
## Summary
- `benchmark` command runs all tasks across all providers/models with cost estimation
- Cost estimator warns and requires confirmation when estimated cost exceeds $2
- `install-schedule` generates launchd plist for daily 6am benchmarks with API keys
- `uninstall-schedule` removes the launchd agent
- macOS notification on completion with 3-line summary (runs/errors/cost)

## Test plan
- [x] All 48 tests pass (8 new benchmark tests + 40 existing)
- [x] Local providers (ollama, mlx) estimated at $0
- [x] API providers (openai, anthropic) cost scales linearly with repeats and tasks
- [x] Notification formatting includes all key metrics

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)