### PR TITLE
Add grounding and attribution scoring for hallucination detection

### DIFF
--- a/observatory/cli.py
+++ b/observatory/cli.py
@@ -14,6 +14,7 @@ from observatory.benchmark import (
 from observatory.analysis import run_full_analysis, generate_findings
 from observatory.dashboard import generate_dashboard
 from observatory.db import BenchmarkDB, get_connection
+from observatory.grounding import GroundingJudge, GROUNDING_CATEGORIES
 from observatory.metrics import BenchmarkMetrics
 from observatory.quality import QualityJudge
 from observatory.runners import RUNNERS
@@ -576,6 +577,100 @@ def analyze(
     findings = generate_findings(result)
     Path(output).write_text(findings)
     console.print(f"\n[green]Findings written to {output}[/green]")
+
+
+@app.command()
+def grounding(
+    provider: str = typer.Option(None, "--provider", "-p", help="Filter by provider"),
+    model: str = typer.Option(None, "--model", "-m", help="Filter by model"),
+    task_id: str = typer.Option(None, "--task", "-t", help="Score a single task"),
+):
+    """Score grounding and detect hallucinations in existing run outputs."""
+    conn = get_connection()
+
+    where_clauses = [
+        "output_text IS NOT NULL",
+        "output_text != ''",
+        "t.category IN ('summarization', 'qa')",
+    ]
+    params = []
+    if provider:
+        where_clauses.append("r.provider = ?")
+        params.append(provider)
+    if model:
+        where_clauses.append("r.model = ?")
+        params.append(model)
+    if task_id:
+        where_clauses.append("r.task_id = ?")
+        params.append(task_id)
+
+    where = f"WHERE {' AND '.join(where_clauses)}"
+
+    rows = conn.execute(
+        f"""
+        SELECT r.id, r.provider, r.model, r.task_id, r.output_text, t.prompt, t.category
+        FROM runs r JOIN tasks t ON r.task_id = t.id
+        {where}
+        ORDER BY r.provider, r.model, r.task_id
+        """,
+        params,
+    ).fetchall()
+
+    if not rows:
+        console.print("[yellow]No runs to score for grounding (summarization/qa only).[/yellow]")
+        return
+
+    judge = GroundingJudge()
+    console.print(f"Scoring grounding for {len(rows)} runs...\n")
+
+    for run_id, prov, mod, tid, output, prompt, category in rows:
+        console.print(f"  [cyan]{tid}[/cyan] ({prov}/{mod})...", end=" ")
+
+        # Use the prompt as source context (in real use, this would be the transcript)
+        result = judge.score(prompt, output)
+        if result.error:
+            console.print(f"[red]ERROR: {result.error}[/red]")
+            continue
+
+        score_color = "green" if result.grounding_score >= 0.8 else "yellow" if result.grounding_score >= 0.5 else "red"
+        console.print(
+            f"[{score_color}]{result.grounding_score:.0%}[/{score_color}] grounded "
+            f"({result.grounded_claims}/{result.total_claims} claims) "
+            f"citations:{result.citations_found} "
+            f"{'hedges' if result.uncertainty_expressed else 'confident'}"
+        )
+
+        if result.ungrounded_claims:
+            for claim in result.ungrounded_claims[:3]:
+                console.print(f"    [red]hallucination:[/red] {claim}")
+
+        conn.execute(
+            "UPDATE runs SET grounding_score = ? WHERE id = ?",
+            [result.grounding_score, run_id],
+        )
+
+    console.print("\n[green]Grounding scores saved to database.[/green]")
+
+    # Show provider-level summary
+    summary_rows = conn.execute("""
+        SELECT provider, model, COUNT(*) as runs,
+            AVG(grounding_score) as avg_grounding,
+            SUM(CASE WHEN grounding_score < 0.8 THEN 1 ELSE 0 END) * 100.0 / COUNT(*) as halluc_pct
+        FROM runs WHERE grounding_score IS NOT NULL
+        GROUP BY provider, model ORDER BY avg_grounding DESC
+    """).fetchall()
+
+    if summary_rows:
+        console.print("\n[bold]Provider Trustworthiness:[/bold]")
+        table = Table()
+        table.add_column("Provider", style="magenta")
+        table.add_column("Model", style="cyan")
+        table.add_column("Runs", justify="right")
+        table.add_column("Grounding", justify="right", style="green")
+        table.add_column("Halluc %", justify="right", style="red")
+        for r in summary_rows:
+            table.add_row(r[0], r[1], str(r[2]), f"{r[3]:.0%}", f"{r[4]:.0f}%")
+        console.print(table)
 
 
 if __name__ == "__main__":

--- a/observatory/dashboard.py
+++ b/observatory/dashboard.py
@@ -12,14 +12,15 @@ REPORTS_DIR = Path("reports")
 def _query_scatter_data(db: BenchmarkDB) -> list[dict]:
     """Cost vs Quality scatter data with Pareto frontier."""
     rows = db.conn.execute("""
-        SELECT provider, model, AVG(cost_usd) as avg_cost, AVG(quality_score) as avg_quality
+        SELECT provider, model, AVG(cost_usd) as avg_cost, AVG(quality_score) as avg_quality,
+            AVG(grounding_score) as avg_grounding
         FROM runs WHERE quality_score IS NOT NULL
         GROUP BY provider, model
     """).fetchall()
     pareto = {(r["provider"], r["model"]) for r in db.get_pareto_front()}
     return [
         {"provider": r[0], "model": r[1], "cost": r[2], "quality": r[3],
-         "pareto": (r[0], r[1]) in pareto}
+         "grounding": r[4], "pareto": (r[0], r[1]) in pareto}
         for r in rows
     ]
 
@@ -30,10 +31,11 @@ def _query_comparison_table(db: BenchmarkDB) -> list[dict]:
         SELECT provider, model, COUNT(*) as runs,
             AVG(latency_ms) as avg_latency, AVG(cost_usd) as avg_cost,
             AVG(quality_score) as avg_quality,
-            AVG(tokens_out) * 1000.0 / NULLIF(AVG(latency_ms), 0) as tok_per_sec
+            AVG(tokens_out) * 1000.0 / NULLIF(AVG(latency_ms), 0) as tok_per_sec,
+            AVG(grounding_score) as avg_grounding
         FROM runs GROUP BY provider, model ORDER BY provider, model
     """).fetchall()
-    cols = ["provider", "model", "runs", "avg_latency", "avg_cost", "avg_quality", "tok_per_sec"]
+    cols = ["provider", "model", "runs", "avg_latency", "avg_cost", "avg_quality", "tok_per_sec", "avg_grounding"]
     return [dict(zip(cols, r)) for r in rows]
 
 
@@ -170,7 +172,7 @@ def _render_html(
   <div class="card full">
     <h2>Provider Comparison</h2>
     <table>
-      <thead><tr><th>Provider</th><th>Model</th><th>Runs</th><th>Avg Latency</th><th>Avg Cost</th><th>Quality</th><th>tok/s</th></tr></thead>
+      <thead><tr><th>Provider</th><th>Model</th><th>Runs</th><th>Avg Latency</th><th>Avg Cost</th><th>Quality</th><th>tok/s</th><th>Grounding</th></tr></thead>
       <tbody id="comparisonBody"></tbody>
     </table>
   </div>
@@ -234,7 +236,8 @@ const compBody = document.getElementById('comparisonBody');
 comparison.forEach(r => {{
   compBody.innerHTML += `<tr><td>${{r.provider}}</td><td>${{r.model}}</td><td>${{r.runs}}</td>` +
     `<td>${{r.avg_latency?.toFixed(0) || '—'}}ms</td><td>${{r.avg_cost?.toFixed(6) || '—'}}</td>` +
-    `<td>${{r.avg_quality?.toFixed(1) || '—'}}</td><td>${{r.tok_per_sec?.toFixed(1) || '—'}}</td></tr>`;
+    `<td>${{r.avg_quality?.toFixed(1) || '—'}}</td><td>${{r.tok_per_sec?.toFixed(1) || '—'}}</td>` +
+    `<td>${{r.avg_grounding ? (r.avg_grounding * 100).toFixed(0) + '%' : '—'}}</td></tr>`;
 }});
 
 // Winners table

--- a/observatory/db.py
+++ b/observatory/db.py
@@ -31,7 +31,8 @@ CREATE TABLE IF NOT EXISTS runs (
     avg_cpu_percent DOUBLE,
     avg_memory_percent DOUBLE,
     run_index INTEGER DEFAULT 0,
-    batch_id VARCHAR
+    batch_id VARCHAR,
+    grounding_score DOUBLE
 );
 """
 

--- a/observatory/grounding.py
+++ b/observatory/grounding.py
@@ -1,0 +1,148 @@
+"""Grounding and attribution scoring — detect hallucinations and measure trustworthiness."""
+
+import json
+from dataclasses import dataclass, field
+
+from anthropic import Anthropic
+
+JUDGE_MODEL = "claude-sonnet-4-6-20260320"
+
+GROUNDING_CATEGORIES = {"summarization", "qa"}
+
+
+@dataclass
+class GroundingResult:
+    grounding_score: float  # 0.0-1.0, % of claims traceable to source
+    total_claims: int
+    grounded_claims: int
+    ungrounded_claims: list[str] = field(default_factory=list)
+    citations_found: int = 0
+    uncertainty_expressed: bool = False
+    reasoning: str = ""
+    error: str | None = None
+
+
+@dataclass
+class HallucinationReport:
+    provider: str
+    model: str
+    total_outputs: int
+    avg_grounding_score: float
+    hallucination_rate: float  # % of outputs with ungrounded claims
+    expresses_uncertainty_rate: float  # % of outputs that hedge appropriately
+    flagged_outputs: list[dict] = field(default_factory=list)
+
+
+def _build_grounding_prompt(source_text: str, output: str) -> str:
+    return f"""You are an expert fact-checker. Analyze the following LLM output and determine which claims are grounded in the source material.
+
+## Source Material
+{source_text}
+
+## LLM Output to Evaluate
+{output}
+
+## Instructions
+1. Identify every factual claim in the output
+2. For each claim, determine if it is directly traceable to the source material
+3. Count any citations or source references in the output
+4. Note if the output expresses uncertainty or hedging (e.g., "according to the transcript", "it appears that")
+
+Respond with ONLY valid JSON:
+{{
+  "total_claims": <int>,
+  "grounded_claims": <int>,
+  "ungrounded_claims": ["claim 1 not in source", "claim 2 not in source"],
+  "citations_found": <int - number of explicit source references>,
+  "uncertainty_expressed": <bool - does the output hedge or express uncertainty>,
+  "reasoning": "Brief explanation"
+}}"""
+
+
+class GroundingJudge:
+    """Scores how well LLM outputs are grounded in source material."""
+
+    def __init__(self):
+        self.client = Anthropic()
+        self.model = JUDGE_MODEL
+
+    def score(self, source_text: str, output: str) -> GroundingResult:
+        """Score grounding of a single output against source material."""
+        if not source_text or not output:
+            return GroundingResult(
+                grounding_score=0.0, total_claims=0, grounded_claims=0,
+                error="Empty source or output",
+            )
+
+        prompt = _build_grounding_prompt(source_text, output)
+
+        try:
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=1024,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = response.content[0].text.strip()
+            if text.startswith("```"):
+                text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+            data = json.loads(text)
+
+            total = int(data["total_claims"])
+            grounded = int(data["grounded_claims"])
+            score = grounded / total if total > 0 else 0.0
+
+            return GroundingResult(
+                grounding_score=round(score, 3),
+                total_claims=total,
+                grounded_claims=grounded,
+                ungrounded_claims=data.get("ungrounded_claims", []),
+                citations_found=int(data.get("citations_found", 0)),
+                uncertainty_expressed=bool(data.get("uncertainty_expressed", False)),
+                reasoning=data.get("reasoning", ""),
+            )
+        except Exception as e:
+            return GroundingResult(
+                grounding_score=0.0, total_claims=0, grounded_claims=0,
+                error=str(e),
+            )
+
+    def build_hallucination_report(
+        self, provider: str, model: str, outputs: list[dict],
+    ) -> HallucinationReport:
+        """Score multiple outputs and build a provider-level hallucination report.
+
+        Each output dict should have: source_text, output_text, task_id
+        """
+        results = []
+        flagged = []
+
+        for entry in outputs:
+            result = self.score(entry["source_text"], entry["output_text"])
+            if result.error:
+                continue
+            results.append(result)
+            if result.ungrounded_claims:
+                flagged.append({
+                    "task_id": entry.get("task_id", ""),
+                    "grounding_score": result.grounding_score,
+                    "ungrounded_claims": result.ungrounded_claims,
+                })
+
+        if not results:
+            return HallucinationReport(
+                provider=provider, model=model, total_outputs=0,
+                avg_grounding_score=0.0, hallucination_rate=0.0,
+                expresses_uncertainty_rate=0.0,
+            )
+
+        avg_score = sum(r.grounding_score for r in results) / len(results)
+        halluc_rate = sum(1 for r in results if r.ungrounded_claims) / len(results)
+        uncert_rate = sum(1 for r in results if r.uncertainty_expressed) / len(results)
+
+        return HallucinationReport(
+            provider=provider, model=model, total_outputs=len(results),
+            avg_grounding_score=round(avg_score, 3),
+            hallucination_rate=round(halluc_rate, 3),
+            expresses_uncertainty_rate=round(uncert_rate, 3),
+            flagged_outputs=flagged,
+        )

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -1,0 +1,135 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from observatory.grounding import (
+    GroundingJudge,
+    GroundingResult,
+    HallucinationReport,
+    GROUNDING_CATEGORIES,
+    _build_grounding_prompt,
+)
+
+
+def test_grounding_categories():
+    assert "summarization" in GROUNDING_CATEGORIES
+    assert "qa" in GROUNDING_CATEGORIES
+
+
+def test_build_grounding_prompt():
+    prompt = _build_grounding_prompt("Source text here", "Output text here")
+    assert "Source text here" in prompt
+    assert "Output text here" in prompt
+    assert "total_claims" in prompt
+    assert "grounded_claims" in prompt
+
+
+def test_grounding_result_defaults():
+    r = GroundingResult(grounding_score=0.8, total_claims=10, grounded_claims=8)
+    assert r.grounding_score == 0.8
+    assert r.ungrounded_claims == []
+    assert r.citations_found == 0
+    assert r.error is None
+
+
+def test_grounding_judge_empty_input():
+    judge = GroundingJudge.__new__(GroundingJudge)
+    result = judge.score("", "some output")
+    assert result.error is not None
+    assert result.grounding_score == 0.0
+
+
+def test_grounding_judge_score():
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=json.dumps({
+        "total_claims": 5,
+        "grounded_claims": 4,
+        "ungrounded_claims": ["CEO founded in 2020"],
+        "citations_found": 2,
+        "uncertainty_expressed": True,
+        "reasoning": "Mostly grounded",
+    }))]
+
+    with patch("observatory.grounding.Anthropic") as MockClient:
+        mock_client = MagicMock()
+        MockClient.return_value = mock_client
+        mock_client.messages.create.return_value = mock_response
+
+        judge = GroundingJudge()
+        result = judge.score("Source about a company", "Output about the company")
+        assert result.grounding_score == 0.8
+        assert result.total_claims == 5
+        assert result.grounded_claims == 4
+        assert len(result.ungrounded_claims) == 1
+        assert result.citations_found == 2
+        assert result.uncertainty_expressed is True
+        assert result.error is None
+
+
+def test_grounding_judge_handles_code_blocks():
+    json_str = json.dumps({
+        "total_claims": 3, "grounded_claims": 3,
+        "ungrounded_claims": [], "citations_found": 0,
+        "uncertainty_expressed": False, "reasoning": "All grounded",
+    })
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=f"```json\n{json_str}\n```")]
+
+    with patch("observatory.grounding.Anthropic") as MockClient:
+        mock_client = MagicMock()
+        MockClient.return_value = mock_client
+        mock_client.messages.create.return_value = mock_response
+
+        judge = GroundingJudge()
+        result = judge.score("Source", "Output")
+        assert result.grounding_score == 1.0
+        assert result.total_claims == 3
+
+
+def test_hallucination_report_empty():
+    judge = GroundingJudge.__new__(GroundingJudge)
+    report = judge.build_hallucination_report("openai", "gpt-4o", [])
+    assert report.total_outputs == 0
+    assert report.avg_grounding_score == 0.0
+
+
+def test_hallucination_report_with_data():
+    results = [
+        {"total_claims": 5, "grounded_claims": 4, "ungrounded_claims": ["x"],
+         "citations_found": 1, "uncertainty_expressed": True, "reasoning": "ok"},
+        {"total_claims": 3, "grounded_claims": 3, "ungrounded_claims": [],
+         "citations_found": 0, "uncertainty_expressed": False, "reasoning": "good"},
+    ]
+    call_count = {"n": 0}
+
+    def mock_create(**kwargs):
+        resp = MagicMock()
+        resp.content = [MagicMock(text=json.dumps(results[call_count["n"]]))]
+        call_count["n"] += 1
+        return resp
+
+    with patch("observatory.grounding.Anthropic") as MockClient:
+        mock_client = MagicMock()
+        MockClient.return_value = mock_client
+        mock_client.messages.create.side_effect = mock_create
+
+        judge = GroundingJudge()
+        outputs = [
+            {"source_text": "src1", "output_text": "out1", "task_id": "sum-01"},
+            {"source_text": "src2", "output_text": "out2", "task_id": "sum-02"},
+        ]
+        report = judge.build_hallucination_report("openai", "gpt-4o", outputs)
+        assert report.total_outputs == 2
+        assert report.avg_grounding_score > 0
+        assert report.hallucination_rate == 0.5  # 1 of 2 had ungrounded claims
+        assert report.expresses_uncertainty_rate == 0.5
+        assert len(report.flagged_outputs) == 1
+
+
+def test_hallucination_report_dataclass():
+    report = HallucinationReport(
+        provider="ollama", model="llama3.2", total_outputs=10,
+        avg_grounding_score=0.7, hallucination_rate=0.3,
+        expresses_uncertainty_rate=0.2,
+    )
+    assert report.provider == "ollama"
+    assert report.hallucination_rate == 0.3


### PR DESCRIPTION
## Summary
- `GroundingJudge` using claude-sonnet-4-6 to measure what % of output claims are traceable to source material
- `GroundingResult`: grounding_score (0-1), ungrounded claims list, citation count, uncertainty detection
- `HallucinationReport`: provider-level aggregation with hallucination rate and uncertainty expression rate
- CLI `grounding` command scores summarization/qa runs and displays provider trustworthiness table
- `grounding_score` column added to `runs` table as 4th dimension
- Dashboard comparison table updated with grounding % column

## Test plan
- [x] All 76 tests pass (9 new grounding tests + 67 existing)
- [x] Grounding judge scores claims and detects ungrounded assertions
- [x] Handles markdown code block wrapping
- [x] Empty input returns proper error
- [x] Hallucination report correctly aggregates rates across outputs
- [x] Dashboard queries include grounding_score

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)